### PR TITLE
Add FastAPI starter project structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
 # ghibili
+
+This repository contains a starter FastAPI project structure.
+
+## Development
+
+Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+Run the application:
+
+```bash
+uvicorn app.main:app --reload
+```

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,7 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get("/")
+def read_root():
+    return {"message": "Hello, world!"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn


### PR DESCRIPTION
## Summary
- scaffold minimal FastAPI app with root endpoint
- add requirements and development docs
- ignore compiled Python bytecode

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile app/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68958fc3b8a08320901ac35185681a14